### PR TITLE
Bump peerDependencies "mongoose" to 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mongoose"
   ],
   "peerDependencies": {
-    "mongoose": ">= 3.5.0 < 4"
+    "mongoose": ">= 3.5.0 < 4.1.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Mongoose versions are now 4.0.x, so npm install throws EPEERINVALID for mongoose-shortid-nodeps.
Can we bump the peerDependencies for mongoose to support at least through 4.0.x (if not further)?