### PR TITLE
Handle alternate form of mongoose 11000 error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ mongoose.Model.prototype.save = function(cb) {
             defaultSave.call(self, function(err, obj) {
               if (err &&
                             err.code == 11000 &&
-                  err.err.indexOf(fieldName) !== -1 &&
+                  (err.err || err.errmsg || '').indexOf(fieldName) !== -1 &&
                             retries > 0
                  ) {
                 --retries;


### PR DESCRIPTION
It seems with Mongoose 4.0.3 the error message was in `err.errmsg` and not in `err.err`.